### PR TITLE
Seleção de conquista

### DIFF
--- a/AppDuolingoClone/ContentViews/ProfileAchievementsContentView.xaml
+++ b/AppDuolingoClone/ContentViews/ProfileAchievementsContentView.xaml
@@ -9,6 +9,7 @@
         <ListView
             CachingStrategy="RecycleElement"
             HasUnevenRows="True"
+            ItemSelected="OnAchievementSelected"
             ItemsSource="{Binding Achievements}"
             SeparatorVisibility="None">
             <ListView.ItemTemplate>

--- a/AppDuolingoClone/ContentViews/ProfileAchievementsContentView.xaml.cs
+++ b/AppDuolingoClone/ContentViews/ProfileAchievementsContentView.xaml.cs
@@ -10,5 +10,10 @@ namespace AppDuolingoClone.ContentViews
         {
             InitializeComponent();
         }
+
+        void OnAchievementSelected(object sender, SelectedItemChangedEventArgs e)
+        {
+            if (sender is ListView lv) lv.SelectedItem = null;
+        }
     }
 }


### PR DESCRIPTION
Ao selecionar a conquista no Android o item da linha da lista ficava laranja. Ainda falta desabilitar o efeito ao tocar no item da lista pra ficar identico ao Duolingo